### PR TITLE
Fix batching mechanism

### DIFF
--- a/src/Jaeger/Transport/TransportUdp.php
+++ b/src/Jaeger/Transport/TransportUdp.php
@@ -20,6 +20,7 @@ use Jaeger\Jaeger;
 use Jaeger\JaegerThrift;
 use Jaeger\Sender\Sender;
 use Jaeger\Sender\UdpSender;
+use Jaeger\Span;
 use Jaeger\Thrift\Agent\AgentClient;
 use Jaeger\Thrift\Batch;
 use Jaeger\Thrift\Process;
@@ -106,12 +107,13 @@ class TransportUdp implements Transport
 
         $thriftSpansBuffer = [];  // Uncommitted span used to temporarily store shards
 
+        /** @var Span $span */
         foreach ($jaeger->spans as $span) {
             $spanThrift = $this->jaegerThrift->buildSpanThrift($span);
             $spanSize = $this->getAndCalcSizeOfSerializedThrift($spanThrift);
             if ($spanSize > self::$maxBatchSpanBytes) {
                 trigger_error(
-                    "Span size of span {$span->getName()} ($spanSize) is too large to fit in UDP packet when considering overhead",
+                    "Span size of span {$span->getOperationName()} ($spanSize) is too large to fit in UDP packet when considering overhead",
                     E_USER_WARNING,
                 );
                 continue;

--- a/tests/Transport/TransportUdpTest.php
+++ b/tests/Transport/TransportUdpTest.php
@@ -20,7 +20,9 @@ use Jaeger\Reporter\RemoteReporter;
 use Jaeger\Sampler\ConstSampler;
 use Jaeger\ScopeManager;
 use Jaeger\Sender\Sender;
+use Jaeger\Thrift\Batch;
 use Jaeger\Transport\TransportUdp;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class TransportUdpTest extends TestCase
@@ -35,12 +37,18 @@ class TransportUdpTest extends TestCase
      */
     public $tracer;
 
+
+    /**
+     * @var Sender|MockObject $senderMock
+     */
+    private $senderMock;
+
     public function setUp(): void
     {
-        $senderMock = $this->createMock(Sender::class);
-        $senderMock->method('emitBatch')->willReturn(true);
+        $this->senderMock = $this->createMock(Sender::class);
+        $this->senderMock->method('emitBatch')->willReturn(true);
 
-        $this->tran = new TransportUdp('localhost:6831', 0, $senderMock);
+        $this->tran = new TransportUdp('localhost:6831', 0, $this->senderMock);
 
         $reporter = new RemoteReporter($this->tran);
         $sampler = new ConstSampler();
@@ -55,5 +63,49 @@ class TransportUdpTest extends TestCase
         $span->finish();
         $this->tran->buildAndCalcSizeOfProcessThrift($this->tracer);
         static::assertEquals(95, $this->tran->procesSize);
+    }
+
+    public function testAppendBatching(): void
+    {
+        $spanCount = 1000;
+        for ($i = 0; $i < $spanCount; $i++) {
+            $span = $this->tracer->startSpan(
+                __METHOD__ . "::$i",
+                [
+                    'tags' => [
+                        'class' => __CLASS__,
+                        'method' => __METHOD__,
+                        'large' => str_repeat('xy', 100),
+                    ],
+                ]
+            );
+            $span->finish();
+        }
+
+        $batchNumber = 0;
+        $flushedSpanCounts = [-1 => 0];
+        $this->senderMock
+            ->method('emitBatch')
+            ->with($this->callback(function (Batch $batch) use (&$batchNumber, &$flushedSpanCounts) {
+                $spanCount = count($batch->spans);
+                $flushedSpanCounts[$batchNumber] = $spanCount;
+                $flushedSpanCounts[-1] += $spanCount;
+                $batchNumber++;
+                return true;
+            }));
+
+
+        $this->tran->append($this->tracer);
+
+        $this->assertEquals([
+            -1 => 1000,
+            0 => 152,
+            1 => 152,
+            2 => 152,
+            3 => 152,
+            4 => 152,
+            5 => 152,
+            6 => 88,
+        ], $flushedSpanCounts);
     }
 }


### PR DESCRIPTION
The batching mechanism would typically send more bytes than the max allowed when emitting any payloads larger than what's allowed for a UPD packet. This fixes that.